### PR TITLE
Implement Git adapters and bootstrap main entry point

### DIFF
--- a/elka/adapters/git/base.py
+++ b/elka/adapters/git/base.py
@@ -1,0 +1,35 @@
+"""Abstraktní definice rozhraní pro Git adaptéry."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Dict, List
+
+
+class BaseGitAdapter(ABC):
+    """Základní abstraktní třída pro Git adaptéry."""
+
+    def __init__(self, repo_url: str, token: str) -> None:
+        self.repo_url = repo_url
+        self.token = token
+
+    @abstractmethod
+    def get_pr_files(self, pr_id: int) -> List[Dict[str, str]]:
+        """Vrátí seznam souborů v Pull Requestu."""
+
+    @abstractmethod
+    def get_file_content(self, file_path: str, branch: str) -> str:
+        """Vrátí obsah jednoho souboru z dané větve."""
+
+    @abstractmethod
+    def post_comment_on_pr(self, pr_id: int, comment: str) -> None:
+        """Přidá komentář k Pull Requestu."""
+
+    @abstractmethod
+    def update_pr_branch(
+        self,
+        pr_id: int,
+        files_to_commit: Dict[str, str],
+        commit_message: str,
+    ) -> None:
+        """Přidá nový commit do větve Pull Requestu s novými/upravenými soubory."""

--- a/elka/adapters/git/gitea.py
+++ b/elka/adapters/git/gitea.py
@@ -1,0 +1,32 @@
+"""Příprava Gitea adaptéru."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+from .base import BaseGitAdapter
+
+
+class GiteaAdapter(BaseGitAdapter):
+    """Základní kostra Gitea adaptéru."""
+
+    def get_pr_files(self, pr_id: int) -> List[Dict[str, str]]:  # pragma: no cover - zatím neimplementováno
+        # TODO: Implementovat pomocí Gitea API
+        pass
+
+    def get_file_content(self, file_path: str, branch: str) -> str:  # pragma: no cover - zatím neimplementováno
+        # TODO: Implementovat pomocí Gitea API
+        pass
+
+    def post_comment_on_pr(self, pr_id: int, comment: str) -> None:  # pragma: no cover - zatím neimplementováno
+        # TODO: Implementovat pomocí Gitea API
+        pass
+
+    def update_pr_branch(
+        self,
+        pr_id: int,
+        files_to_commit: Dict[str, str],
+        commit_message: str,
+    ) -> None:  # pragma: no cover - zatím neimplementováno
+        # TODO: Implementovat pomocí Gitea API
+        pass

--- a/elka/adapters/git/github.py
+++ b/elka/adapters/git/github.py
@@ -1,0 +1,62 @@
+"""Implementace GitHub adaptéru pro práci s GitHub API."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+from github import Github, InputGitTreeElement
+from github.Repository import Repository
+
+from .base import BaseGitAdapter
+
+
+class GitHubAdapter(BaseGitAdapter):
+    """GitHub adaptér založený na PyGithub."""
+
+    def __init__(self, repo_url: str, token: str) -> None:
+        super().__init__(repo_url, token)
+        self.client = Github(token)
+        normalized = repo_url.strip("/")
+        if not normalized:
+            raise ValueError("Repozitářní URL musí být ve formátu 'owner/repo'.")
+        self.repository: Repository = self.client.get_repo(normalized)
+
+    def get_pr_files(self, pr_id: int) -> List[Dict[str, str]]:
+        pr = self.repository.get_pull(pr_id)
+        return [{"filename": file.filename, "status": file.status} for file in pr.get_files()]
+
+    def get_file_content(self, file_path: str, branch: str) -> str:
+        content_file = self.repository.get_contents(file_path, ref=branch)
+        return content_file.decoded_content.decode("utf-8")
+
+    def post_comment_on_pr(self, pr_id: int, comment: str) -> None:
+        pr = self.repository.get_pull(pr_id)
+        pr.create_issue_comment(comment)
+
+    def update_pr_branch(
+        self,
+        pr_id: int,
+        files_to_commit: Dict[str, str],
+        commit_message: str,
+    ) -> None:
+        if not files_to_commit:
+            return
+
+        pr = self.repository.get_pull(pr_id)
+        head_repo: Repository = pr.head.repo
+        branch_ref = head_repo.get_git_ref(f"heads/{pr.head.ref}")
+        last_commit = head_repo.get_git_commit(branch_ref.object.sha)
+
+        tree_elements = []
+        for path, content in files_to_commit.items():
+            element = InputGitTreeElement(
+                path=path,
+                mode="100644",
+                type="blob",
+                content=content,
+            )
+            tree_elements.append(element)
+
+        new_tree = head_repo.create_git_tree(tree_elements, base_tree=last_commit.tree)
+        new_commit = head_repo.create_git_commit(commit_message, new_tree, [last_commit])
+        branch_ref.edit(new_commit.sha)

--- a/elka/main.py
+++ b/elka/main.py
@@ -1,0 +1,80 @@
+"""Hlavní vstupní bod pro eLKA agenta."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+from typing import Dict, Type
+
+from elka.adapters.git.base import BaseGitAdapter
+from elka.adapters.git.gitea import GiteaAdapter
+from elka.adapters.git.github import GitHubAdapter
+from elka.utils.config import Config
+
+
+GIT_ADAPTERS: Dict[str, Type[BaseGitAdapter]] = {
+    "github": GitHubAdapter,
+    "gitea": GiteaAdapter,
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Spuštění eLKA agenta")
+    default_config = Path(__file__).resolve().parent / "config.yml"
+    parser.add_argument("--config", type=Path, default=default_config, help="Cesta ke konfiguračnímu souboru")
+    parser.add_argument("--pr-id", type=int, required=False, help="Identifikátor Pull Requestu")
+    return parser.parse_args()
+
+
+def configure_logging(config: Config) -> None:
+    logging_config = config.logging
+    level_name = str(logging_config.get("level", "INFO")).upper()
+    level = getattr(logging, level_name, logging.INFO)
+
+    log_kwargs = {
+        "level": level,
+        "format": "%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    }
+
+    log_file = logging_config.get("file")
+    if log_file:
+        log_kwargs["filename"] = log_file
+
+    logging.basicConfig(**log_kwargs)
+
+
+def create_git_adapter(config: Config) -> BaseGitAdapter:
+    platform = (config.git_platform or "").lower()
+    adapter_cls = GIT_ADAPTERS.get(platform)
+    if adapter_cls is None:
+        raise ValueError(f"Nepodporovaná Git platforma: {platform}")
+
+    repo_url = config.git.get("repo_url")
+    if not repo_url:
+        raise ValueError("V konfiguraci musí být nastavena položka git.repo_url.")
+
+    token = config.git_api_token
+    if not token:
+        raise ValueError("Git API token musí být k dispozici v konfiguraci nebo prostředí.")
+
+    return adapter_cls(repo_url, token)
+
+
+def main() -> None:
+    args = parse_args()
+    config = Config(args.config)
+    configure_logging(config)
+
+    adapter = create_git_adapter(config)
+    logger = logging.getLogger(__name__)
+    logger.info("Inicializován adaptér: %s", adapter.__class__.__name__)
+
+    if args.pr_id is not None:
+        logger.info("Spuštěno pro PR ID: %s", args.pr_id)
+
+    print(f"Inicializován adaptér: {adapter.__class__.__name__}")
+
+
+if __name__ == "__main__":
+    main()

--- a/elka/requirements.txt
+++ b/elka/requirements.txt
@@ -1,2 +1,3 @@
 PyYAML
 python-dotenv
+PyGithub


### PR DESCRIPTION
## Summary
- add abstract BaseGitAdapter interface for Git integrations
- implement GitHub adapter with PyGithub and scaffold a Gitea adapter
- wire up the CLI entrypoint to load configuration and create the proper adapter
- declare the PyGithub dependency

## Testing
- python -m compileall elka

------
https://chatgpt.com/codex/tasks/task_e_68da578545888333a945ee6cd85f8c6a