### PR TITLE
Add autonomous story generator engine

### DIFF
--- a/docs/generator-engine.md
+++ b/docs/generator-engine.md
@@ -1,0 +1,29 @@
+# Generator Engine
+
+Autonomní generátor rozšiřuje schopnosti eLKA agenta o tvorbu nových příběhů bez nutnosti zásahu člověka.
+
+## Pracovní postup
+
+1. **Načtení kánonu** – stáhne aktuální stav hlavní větve a připraví vstup pro AI modely.
+2. **Analýza mezer** – výkonný `generator` model navrhne pět možných námětů ve formátu JSON. Náhodně je vybrán jeden.
+3. **Psaní příběhu** – stejný model vytvoří kompletní příběh včetně metadat, přičemž respektuje legendy a pravidla z adresáře `Pokyny/`.
+4. **Validace** – vygenerovaný text projde stávající validační pipeline (formát, kontinuita, tón).
+5. **Archivace** – ArchivistEngine připraví aktualizace databází a timeline.
+6. **Commit & PR** – Git adaptér vytvoří novou větev `elka-generated/<slug>-<timestamp>`, nahraje změny, a založí Pull Request proti stabilní větvi.
+
+## Spuštění
+
+```bash
+python -m elka.main generate --num-stories 3
+```
+
+Parametr `--num-stories` lze vynechat – výchozí hodnota je 1.
+
+## Bezpečnostní pojistky
+
+- Každý příběh musí projít validátorem; v případě selhání se cyklus přeskočí.
+- Pokud Git adaptér nepodporuje tvorbu větví nebo PR, generátor chybu zaloguje a pokračuje až po nápravě prostředí.
+
+## Využití pro redakci
+
+Vytvořené Pull Requesty obsahují shrnutí námětu, odkaz na soubor s příběhem a seznam aktualizovaných databázových záznamů. Redakce tak může rychle posoudit příspěvek a rozhodnout o jeho začlenění do hlavní continuity.

--- a/elka/adapters/git/base.py
+++ b/elka/adapters/git/base.py
@@ -33,3 +33,23 @@ class BaseGitAdapter(ABC):
         commit_message: str,
     ) -> None:
         """Přidá nový commit do větve Pull Requestu s novými/upravenými soubory."""
+
+    @abstractmethod
+    def create_branch_and_commit(
+        self,
+        base_branch: str,
+        new_branch: str,
+        files_to_commit: Dict[str, str],
+        commit_message: str,
+    ) -> str:
+        """Vytvoří novou větev z dané základní větve, přidá commit a vrátí jeho SHA."""
+
+    @abstractmethod
+    def create_pull_request(
+        self,
+        title: str,
+        body: str,
+        head_branch: str,
+        base_branch: str,
+    ) -> str:
+        """Vytvoří Pull Request a vrátí jeho URL nebo identifikátor."""

--- a/elka/adapters/git/gitea.py
+++ b/elka/adapters/git/gitea.py
@@ -30,3 +30,23 @@ class GiteaAdapter(BaseGitAdapter):
     ) -> None:  # pragma: no cover - zatím neimplementováno
         # TODO: Implementovat pomocí Gitea API
         pass
+
+    def create_branch_and_commit(
+        self,
+        base_branch: str,
+        new_branch: str,
+        files_to_commit: Dict[str, str],
+        commit_message: str,
+    ) -> str:  # pragma: no cover - zatím neimplementováno
+        # TODO: Implementovat pomocí Gitea API
+        raise NotImplementedError
+
+    def create_pull_request(
+        self,
+        title: str,
+        body: str,
+        head_branch: str,
+        base_branch: str,
+    ) -> str:  # pragma: no cover - zatím neimplementováno
+        # TODO: Implementovat pomocí Gitea API
+        raise NotImplementedError

--- a/elka/core/generator.py
+++ b/elka/core/generator.py
@@ -1,0 +1,333 @@
+"""Autonomní generátor příběhů využívající existující orchestrátor."""
+
+from __future__ import annotations
+
+import json
+import logging
+import random
+import re
+import subprocess
+import time
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+from elka.adapters.ai.base import BaseAIAdapter
+from elka.adapters.git.base import BaseGitAdapter
+from elka.core.archivist import ArchivistEngine
+from elka.core.validator import ValidatorEngine
+from elka.utils.config import Config
+
+
+class GeneratorEngine:
+    """Engine zajišťující autonomní generování nových příběhů."""
+
+    STORY_DIRECTORY = "Stories"
+
+    def __init__(
+        self,
+        ai_adapter: BaseAIAdapter,
+        git_adapter: BaseGitAdapter,
+        config: Config,
+    ) -> None:
+        self.ai_adapter = ai_adapter
+        self.git_adapter = git_adapter
+        self.config = config
+        self.logger = logging.getLogger(__name__)
+
+        self.validator = ValidatorEngine(ai_adapter=ai_adapter, config=config)
+        self.archivist = ArchivistEngine(ai_adapter=ai_adapter, config=config)
+
+        provider_name = (config.ai_provider or "").lower()
+        providers_config = config.ai.get("providers", {})
+        models_config = providers_config.get(provider_name, {}).get("models", {})
+        self.generator_model = models_config.get("generator")
+        if not self.generator_model:
+            raise ValueError("Konfigurace neobsahuje AI model pro generátor.")
+
+        core_config = config.core or {}
+        self.main_branch = core_config.get("main_branch", "master")
+        rules_path = str(core_config.get("rules_path", "") or "").replace("\\", "/")
+        self.rules_prefix = rules_path.strip("/")
+        self.repo_root = Path(__file__).resolve().parents[2]
+
+    # ------------------------------------------------------------------
+    # Public API
+
+    def run_cycle(self, num_stories: int = 1) -> None:
+        """Spusť jeden nebo více cyklů autonomního generování."""
+
+        for index in range(1, num_stories + 1):
+            self.logger.info("Spouštím autonomní generaci příběhu %s/%s", index, num_stories)
+
+            try:
+                universe_files = self._load_universe_files()
+            except RuntimeError as exc:
+                self.logger.exception("Načtení kánonu selhalo: %s", exc)
+                break
+
+            idea = self._generate_idea(universe_files)
+            if not idea:
+                self.logger.warning("Generátor nevrátil žádný validní námět, cyklus přeskočen.")
+                continue
+
+            try:
+                story_content = self._write_story(idea, universe_files)
+            except Exception as exc:  # pragma: no cover - závislé na AI
+                self.logger.exception("Generování příběhu selhalo: %s", exc)
+                continue
+
+            validation_result = self.validator.validate(story_content, universe_files)
+            if not validation_result.get("passed", False):
+                errors = validation_result.get("errors", [])
+                self.logger.warning(
+                    "Validace generovaného příběhu selhala. Důvody: %s", "; ".join(errors)
+                )
+                continue
+
+            try:
+                archive_updates = self.archivist.archive(story_content, universe_files)
+            except Exception as exc:  # pragma: no cover - závislé na AI
+                self.logger.exception("Archivace generovaného příběhu selhala: %s", exc)
+                continue
+
+            files_to_commit = dict(archive_updates)
+            story_path = self._determine_story_path(story_content)
+            files_to_commit[story_path] = story_content
+
+            story_title = self._extract_metadata_value(story_content, "nazev")
+            if not story_title:
+                story_title = "Neznámý příběh"
+
+            branch_name = self._build_generated_branch_name(story_title)
+            commit_message = f"eLKA: Autonomně vygenerován příběh '{story_title}'."
+
+            try:
+                self.git_adapter.create_branch_and_commit(
+                    self.main_branch,
+                    branch_name,
+                    files_to_commit,
+                    commit_message,
+                )
+            except NotImplementedError:
+                self.logger.error("Git adaptér nepodporuje vytvoření nové větve. Cyklus končí.")
+                break
+            except Exception as exc:  # pragma: no cover - závislé na Git API
+                self.logger.exception("Commit do větve %s selhal: %s", branch_name, exc)
+                continue
+
+            pr_title = f"eLKA: Nový příběh '{story_title}'"
+            pr_body = self._build_pr_body(idea, story_path, archive_updates)
+
+            try:
+                pr_url = self.git_adapter.create_pull_request(
+                    pr_title,
+                    pr_body,
+                    branch_name,
+                    self.main_branch,
+                )
+                if pr_url:
+                    self.logger.info("Autonomní PR vytvořeno: %s", pr_url)
+            except NotImplementedError:
+                self.logger.info("Git adaptér nepodporuje automatické PR – krok přeskočen.")
+            except Exception as exc:  # pragma: no cover - závislé na Git API
+                self.logger.exception("Vytvoření PR pro větev %s selhalo: %s", branch_name, exc)
+
+    # ------------------------------------------------------------------
+    # Generační kroky
+
+    def _generate_idea(self, universe_files: Dict[str, str]) -> Dict[str, str]:
+        canon_content = self._render_files(sorted(universe_files.items()))
+
+        system_prompt = (
+            "Jsi zkušený editor a tvůrce světů. Tvým úkolem je analyzovat existující "
+            "univerzum a navrhnout zajímavé, konzistentní a logické náměty na další "
+            "příběhy, které by ho obohatily."
+        )
+
+        user_prompt = (
+            "Zde je kompletní kánon univerza:\n"
+            "--- KÁNON ---\n"
+            f"{canon_content}\n"
+            "--- KONEC KÁNONU ---\n\n"
+            "Analyzuj tento svět. Hledej nevyřešené otázky, zajímavé vedlejší postavy "
+            "bez vlastního příběhu, neprozkoumaná místa, nejasnosti v historii nebo "
+            "nevyužité artefakty. Na základě své analýzy navrhni PĚT různých námětů na "
+            "další příběh. Každý námět by měl být stručný (2-3 věty) a měl by obsahovat "
+            "název, éru a klíčové entity. Odpověz POUZE ve formátu JSON:\n"
+            "{\n"
+            "  \"ideas\": [\n"
+            "    {\"title\": \"Název námětu 1\", \"era\": \"Druhý věk\", \"summary\": \"Stručný popis námětu 1.\"},\n"
+            "    {\"title\": \"Název námětu 2\", \"era\": \"Čtvrtý věk\", \"summary\": \"...\"}\n"
+            "  ]\n"
+            "}"
+        )
+
+        try:
+            response = self.ai_adapter.prompt(self.generator_model, system_prompt, user_prompt)
+        except Exception as exc:  # pragma: no cover - závislé na AI
+            self.logger.exception("Volání modelu pro generování námětů selhalo: %s", exc)
+            return {}
+
+        try:
+            data = json.loads(response.strip())
+        except json.JSONDecodeError as exc:
+            self.logger.error("Návrhy námětů nejsou platný JSON: %s", exc)
+            return {}
+
+        ideas = data.get("ideas") if isinstance(data, dict) else None
+        if not isinstance(ideas, list):
+            self.logger.error("Odpověď generátoru neobsahuje klíč 'ideas'.")
+            return {}
+
+        valid_ideas = [idea for idea in ideas if isinstance(idea, dict)]
+        if not valid_ideas:
+            self.logger.warning("V JSON odpovědi se nenachází žádné validní náměty.")
+            return {}
+
+        selected = random.choice(valid_ideas)
+        self.logger.info("Vybrán námět: %s", selected.get("title", "bez názvu"))
+        return selected
+
+    def _write_story(self, idea: Dict[str, str], universe_files: Dict[str, str]) -> str:
+        canon_content = self._render_files(sorted(universe_files.items()))
+        rules_content = self._collect_rules_content(universe_files)
+
+        system_prompt = (
+            "Jsi talentovaný vypravěč a spisovatel. Tón a styl tvého psaní je definován "
+            "v souborech legend a pokynů tohoto univerza. Tvým úkolem je napsat poutavý "
+            "a konzistentní příběh."
+        )
+
+        user_prompt = (
+            "Zde je kompletní kánon univerza pro zachování kontinuity:\n"
+            "--- KÁNON ---\n"
+            f"{canon_content}\n"
+            "--- KONEC KÁNONU ---\n\n"
+            "Zde jsou pravidla pro styl a tón:\n"
+            "--- PRAVIDLA ---\n"
+            f"{rules_content}\n"
+            "--- KONEC PRAVIDEL ---\n\n"
+            "Napiš kompletní, ucelený příběh na základě tohoto námětu:\n"
+            f"- Název: {idea.get('title', 'Neznámý')}\n"
+            f"- Éra: {idea.get('era', 'Neznámá')}\n"
+            f"- Shrnutí: {idea.get('summary', 'Bez shrnutí')}\n\n"
+            "Tvůj příběh MUSÍ obsahovat správně formátovaná metadata (id, nazev, era, atd.) na "
+            "začátku. ID souboru si vymysli na základě názvu."
+        )
+
+        response = self.ai_adapter.prompt(self.generator_model, system_prompt, user_prompt)
+        return response.strip()
+
+    # ------------------------------------------------------------------
+    # Helpers
+
+    def _load_universe_files(self) -> Dict[str, str]:
+        file_paths = self._list_branch_files(self.main_branch)
+        universe_files: Dict[str, str] = {}
+        for path in file_paths:
+            universe_files[path] = self.git_adapter.get_file_content(path, self.main_branch)
+        return universe_files
+
+    def _list_branch_files(self, branch: str) -> List[str]:
+        try:
+            result = subprocess.run(
+                ["git", "ls-tree", "-r", branch, "--name-only"],
+                check=True,
+                capture_output=True,
+                text=True,
+                cwd=self.repo_root,
+            )
+        except subprocess.CalledProcessError as exc:  # pragma: no cover - závislé na git
+            raise RuntimeError(f"git ls-tree selhalo: {exc}") from exc
+
+        return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+    def _render_files(self, files: List[Tuple[str, str]]) -> str:
+        rendered_parts = []
+        for path, content in files:
+            rendered_parts.append(
+                f"### START FILE: {path} ###\n{content}\n### END FILE: {path} ###"
+            )
+        return "\n\n".join(rendered_parts)
+
+    def _collect_rules_content(self, universe_files: Dict[str, str]) -> str:
+        if not self.rules_prefix:
+            return ""
+
+        rendered: List[Tuple[str, str]] = []
+        normalized_prefix = self.rules_prefix + "/" if self.rules_prefix else ""
+        for path, content in universe_files.items():
+            normalized = path.replace("\\", "/")
+            while normalized.startswith("./"):
+                normalized = normalized[2:]
+            if normalized.startswith(normalized_prefix):
+                rendered.append((path, content))
+
+        return self._render_files(sorted(rendered)) if rendered else ""
+
+    def _determine_story_path(self, story_content: str) -> str:
+        story_id = self._extract_metadata_value(story_content, "id")
+        if story_id:
+            slug = self._slugify(story_id)
+        else:
+            title = self._extract_metadata_value(story_content, "nazev")
+            slug = self._slugify(title) if title else ""
+
+        if not slug:
+            slug = f"pribeh-{int(time.time())}"
+
+        return f"{self.STORY_DIRECTORY}/{slug}.md"
+
+    def _extract_metadata_value(self, story_content: str, key: str) -> str:
+        search_key = key.strip().lower()
+        for line in story_content.splitlines():
+            if ":" not in line:
+                continue
+            raw_key, value = line.split(":", 1)
+            if raw_key.strip().lower() == search_key:
+                return value.strip()
+        return ""
+
+    def _build_generated_branch_name(self, story_title: str) -> str:
+        slug = self._slugify(story_title)
+        timestamp = int(time.time())
+        if slug:
+            return f"elka-generated/{slug}-{timestamp}"
+        return f"elka-generated/pribeh-{timestamp}"
+
+    def _slugify(self, value: str | None) -> str:
+        if not value:
+            return ""
+        normalized = value.lower()
+        normalized = re.sub(r"[^a-z0-9]+", "-", normalized)
+        return normalized.strip("-")
+
+    def _build_pr_body(
+        self,
+        idea: Dict[str, str],
+        story_path: str,
+        archive_updates: Dict[str, str],
+    ) -> str:
+        summary = idea.get("summary", "")
+        era = idea.get("era", "Neuvedeno")
+        title = idea.get("title", "Bez názvu")
+
+        updates_list = "".join(
+            f"- `{path}`\n" for path in sorted(archive_updates.keys()) if path != story_path
+        )
+        if updates_list:
+            updates_section = (
+                "\n## Aktualizované kanonické soubory\n"
+                f"{updates_list}"
+            )
+        else:
+            updates_section = ""
+
+        return (
+            f"## Autonomně vygenerovaný příběh\n"
+            f"- **Název:** {title}\n"
+            f"- **Éra:** {era}\n"
+            f"- **Soubor:** `{story_path}`\n"
+            f"- **Shrnutí námětu:** {summary}\n"
+            f"{updates_section}\n"
+        )

--- a/elka/main.py
+++ b/elka/main.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import argparse
 import logging
 from pathlib import Path
-from typing import Dict, Tuple, Type
+from typing import Dict, Type
 
 from elka.adapters.ai.base import BaseAIAdapter
 from elka.adapters.ai.gemini import GeminiAdapter
@@ -13,6 +13,7 @@ from elka.adapters.ai.ollama import OllamaAdapter
 from elka.adapters.git.base import BaseGitAdapter
 from elka.adapters.git.gitea import GiteaAdapter
 from elka.adapters.git.github import GitHubAdapter
+from elka.core.generator import GeneratorEngine
 from elka.core.orchestrator import Orchestrator
 from elka.utils.config import Config
 
@@ -31,8 +32,35 @@ AI_ADAPTERS: Dict[str, Type[BaseAIAdapter]] = {
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Spuštění eLKA agenta")
     default_config = Path(__file__).resolve().parent / "config.yml"
-    parser.add_argument("--config", type=Path, default=default_config, help="Cesta ke konfiguračnímu souboru")
-    parser.add_argument("--pr-id", type=int, required=False, help="Identifikátor Pull Requestu")
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=default_config,
+        help="Cesta ke konfiguračnímu souboru",
+    )
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    process_parser = subparsers.add_parser(
+        "process", help="Zpracuje existující Pull Request"
+    )
+    process_parser.add_argument(
+        "--pr-id",
+        type=int,
+        required=True,
+        help="Identifikátor Pull Requestu",
+    )
+
+    generate_parser = subparsers.add_parser(
+        "generate", help="Spustí autonomní generování příběhů"
+    )
+    generate_parser.add_argument(
+        "--num-stories",
+        type=int,
+        default=1,
+        help="Počet příběhů, které se mají vygenerovat",
+    )
+
     return parser.parse_args()
 
 
@@ -91,46 +119,28 @@ def create_ai_adapter(config: Config) -> BaseAIAdapter:
     return adapter_cls(provider_config)
 
 
-def main() -> Tuple[Config, BaseAIAdapter]:
+def main() -> None:
     args = parse_args()
     config = Config(args.config)
     configure_logging(config)
 
     git_adapter = create_git_adapter(config)
     ai_adapter = create_ai_adapter(config)
-    orchestrator = Orchestrator(config, ai_adapter=ai_adapter, git_adapter=git_adapter)
 
     logger = logging.getLogger(__name__)
     logger.info("Inicializován Git adaptér: %s", git_adapter.__class__.__name__)
     logger.info("Inicializován AI adaptér: %s", ai_adapter.__class__.__name__)
 
-    print(f"Inicializován Git adaptér: {git_adapter.__class__.__name__}")
-    print(f"Inicializován AI adaptér: {ai_adapter.__class__.__name__}")
-
-    if args.pr_id is not None:
+    if args.command == "process":
+        orchestrator = Orchestrator(config, ai_adapter=ai_adapter, git_adapter=git_adapter)
         logger.info("Spuštěno pro PR ID: %s", args.pr_id)
         orchestrator.process_pull_request(args.pr_id)
-
-    return config, ai_adapter
+    elif args.command == "generate":
+        generator = GeneratorEngine(ai_adapter=ai_adapter, git_adapter=git_adapter, config=config)
+        logger.info("Spuštěno autonomní generování pro %s příběh(ů)", args.num_stories)
+        generator.run_cycle(num_stories=max(1, args.num_stories))
 
 
 if __name__ == "__main__":
-    config, ai_adapter = main()
-
-    print("Testuji AI adaptér...")
-    try:
-        provider_name = (config.ai_provider or "").lower()
-        providers_config = config.ai.get("providers", {})
-        models_config = providers_config.get(provider_name, {}).get("models", {})
-        test_model_name = models_config.get("validator")
-        if not test_model_name:
-            raise ValueError("V konfiguraci chybí testovací model pro AI adaptér.")
-
-        system_instruction = "Jsi užitečný asistent."
-        user_question = "Kolik je 2 + 2?"
-
-        response = ai_adapter.prompt(test_model_name, system_instruction, user_question)
-        print(f"Odpověď od AI: {response}")
-    except Exception as exc:  # pragma: no cover - může selhat bez externích služeb
-        print(f"Test AI adaptéru selhal: {exc}")
+    main()
 


### PR DESCRIPTION
## Summary
- add a GeneratorEngine that generates, validates, archives, and submits new stories autonomously
- extend Git adapters with helpers for creating branches and pull requests used by the generator
- update the CLI with process/generate subcommands and document the new generator workflow

## Testing
- python -m compileall elka

------
https://chatgpt.com/codex/tasks/task_e_68da68d853bc8333962bcf31963a0632