### PR TITLE
Normalize entity types and enforce English directories

### DIFF
--- a/UNIVERSE_FORMAT.md
+++ b/UNIVERSE_FORMAT.md
@@ -19,6 +19,9 @@ A compliant eLKA universe repository MUST adhere to the following top-level stru
     * `/Entities/Concepts/`: Files describing abstract concepts, world rules, magic systems, etc.
     * `/Entities/Items/`: Files describing specific items.
     * `/Entities/Misc/`: For entities that don't fit elsewhere (use sparingly).
+        * Entity extraction normalises all detected types (including non-English outputs) to these
+          English directory names before archival. Legacy directories such as `Objekty/` are read
+          for backwards compatibility only and MUST NOT be used for new content.
 * `/Stories/`: Contains narrative texts (stories, chapters). May contain subdirectories for organization (e.g., `/Stories/Saga_Name/`).
 * `/Canon/`: Contains foundational lore, history, and rules defining the universe framework.
     * `CoreTruths.md`: Key file with immutable facts used for validation.

--- a/elka-studio/backend/app/core/extractor.py
+++ b/elka-studio/backend/app/core/extractor.py
@@ -73,21 +73,52 @@ _ENTITY_KEY_TO_TYPE: Dict[str, str] = {
 
 _TYPE_SYNONYMS: Dict[str, str] = {
     "character": "Character",
+    "characters": "Character",
+    "charakter": "Character",
     "person": "Character",
     "people": "Character",
     "hero": "Character",
+    "hrdina": "Character",
+    "postava": "Character",
+    "postavy": "Character",
     "location": "Location",
+    "locations": "Location",
     "place": "Location",
     "city": "Location",
+    "lokace": "Location",
+    "lokalita": "Location",
+    "misto": "Location",
+    "místa": "Location",
+    "místo": "Location",
+    "mesta": "Location",
+    "město": "Location",
     "event": "Event",
+    "events": "Event",
     "battle": "Event",
+    "udalost": "Event",
+    "udalosti": "Event",
+    "událost": "Event",
+    "události": "Event",
     "concept": "Concept",
+    "concepts": "Concept",
     "idea": "Concept",
+    "koncept": "Concept",
+    "koncepce": "Concept",
+    "myslenka": "Concept",
+    "myšlenka": "Concept",
     "item": "Item",
+    "items": "Item",
     "object": "Item",
     "artifact": "Item",
+    "predmet": "Item",
+    "predmety": "Item",
+    "předmět": "Item",
+    "předměty": "Item",
+    "artefakt": "Item",
     "misc": "Misc",
     "other": "Misc",
+    "ostatni": "Misc",
+    "ostatní": "Misc",
 }
 
 _ALLOWED_TYPE_LOOKUP: Dict[str, str] = {
@@ -424,12 +455,27 @@ class ExtractorEngine:
         resolved_type = canonical_type
         resolved_label = canonical_type.lower()
         if isinstance(raw_type, str) and raw_type.strip():
-            candidate = _ALLOWED_TYPE_LOOKUP.get(raw_type.strip().lower())
-            if candidate:
-                resolved_type = candidate
-                resolved_label = raw_type.strip().lower()
-            else:
-                raise ValueError(f"Unsupported entity type '{raw_type}'")
+            raw_type_normalised = raw_type.strip().lower()
+            candidate = _ALLOWED_TYPE_LOOKUP.get(raw_type_normalised)
+            if not candidate:
+                ascii_normalised = (
+                    unicodedata.normalize("NFKD", raw_type.strip())
+                    .encode("ascii", "ignore")
+                    .decode("ascii")
+                    .lower()
+                )
+                candidate = _ALLOWED_TYPE_LOOKUP.get(ascii_normalised)
+            if not candidate:
+                logger.warning(
+                    "Extractor received unsupported entity type '%s'; falling back to Misc.",
+                    raw_type,
+                )
+                if canonical_type in _ENTITY_KEY_TO_TYPE.values():
+                    candidate = canonical_type
+                else:
+                    candidate = "Misc"
+            resolved_type = candidate
+            resolved_label = candidate.lower()
         aliases = _normalise_aliases(raw_entity.get("aliases"))
         description = raw_entity.get("description")
         if isinstance(description, str):


### PR DESCRIPTION
## Summary
- expand extractor type synonym mapping to cover Czech outputs and normalise unknown types to supported English labels
- normalise archivist entity preparation and directory selection to always use the standard English /Entities/<Type>/ folders
- document that extraction now coerces all entity types to the UNIVERSE_FORMAT.md directory structure and avoids legacy folders

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fb6e13d6508333819622cf4df1cd1e